### PR TITLE
Fix duplicate Lambda construct instantiation in Chapter4 stack

### DIFF
--- a/chapter4/lib/lambda-ddb-chapter4-stack.ts
+++ b/chapter4/lib/lambda-ddb-chapter4-stack.ts
@@ -10,12 +10,6 @@ export class Chapter4Stack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    new lambdaNodeJs.NodejsFunction(this, 'SampleLambda', {
-      entry: 'src/index.ts',
-      handler: 'handler',
-      runtime: lambda.Runtime.NODEJS_LATEST,
-    });
-
     const table = new dynamodb.TableV2(this, 'SampleTable', {
       partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
       billing: dynamodb.Billing.onDemand(),


### PR DESCRIPTION
## Summary
- remove the redundant NodejsFunction instantiation that reused the SampleLambda id
- keep a single Lambda connected to the DynamoDB table and function URL outputs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d75b1d0b288328a5f4fb7ae365789d